### PR TITLE
Add knobs and switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Several related changes are included in the patchset as well:
 
 **This patchset is prototype-quality at the moment. If `ARB_buffer_storage` is not present, you're not going to have a good time.**
 
-Currently, these patches are based off wine-staging 3.3.
+Currently, these patches are based off wine-staging 3.5.
 
 [Details can be found here.](https://comminos.com/posts/2018-02-21-wined3d-profiling.html)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Several related changes are included in the patchset as well:
 
 **This patchset is prototype-quality at the moment. If `ARB_buffer_storage` is not present, you're not going to have a good time.**
 
-Currently, these patches are based off wine-staging 3.5.
+Currently, these patches are based off wine-staging 3.6.
 
 [Details can be found here.](https://comminos.com/posts/2018-02-21-wined3d-profiling.html)

--- a/patches/0001-wined3d-Initial-implementation-of-a-persistent-mappe.patch
+++ b/patches/0001-wined3d-Initial-implementation-of-a-persistent-mappe.patch
@@ -1,23 +1,23 @@
-From da3cbbdc792eef0783442c1b7baae3db9e6a528d Mon Sep 17 00:00:00 2001
+From aa3a2c59904a460629673d6c4f705b97c01d48fb Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:16:11 +0100
-Subject: [PATCH 1/10] wined3d: Initial implementation of a persistent mapped
+Date: Mon, 5 Mar 2018 15:38:35 -0800
+Subject: [PATCH 01/10] wined3d: Initial implementation of a persistent mapped
  buffer allocator.
 
 ---
  dlls/wined3d/Makefile.in       |   1 +
- dlls/wined3d/buffer_heap.c     | 508 +++++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/buffer_heap.c     | 508 +++++++++++++++++++++++++++++++++
  dlls/wined3d/cs.c              |   9 +
- dlls/wined3d/device.c          |  52 +++++
+ dlls/wined3d/device.c          |  52 ++++
  dlls/wined3d/directx.c         |   3 +
  dlls/wined3d/query.c           |   2 +-
  dlls/wined3d/wined3d_gl.h      |   1 +
- dlls/wined3d/wined3d_private.h |  68 +++++-
+ dlls/wined3d/wined3d_private.h |  68 ++++-
  8 files changed, 640 insertions(+), 4 deletions(-)
  create mode 100644 dlls/wined3d/buffer_heap.c
 
 diff --git a/dlls/wined3d/Makefile.in b/dlls/wined3d/Makefile.in
-index b850ba6..52ef866 100644
+index b850ba6872..52ef8666fb 100644
 --- a/dlls/wined3d/Makefile.in
 +++ b/dlls/wined3d/Makefile.in
 @@ -6,6 +6,7 @@ C_SRCS = \
@@ -30,7 +30,7 @@ index b850ba6..52ef866 100644
  	device.c \
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
 new file mode 100644
-index 0000000..b133bd6
+index 0000000000..b133bd6893
 --- /dev/null
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -0,0 +1,508 @@
@@ -543,7 +543,7 @@ index 0000000..b133bd6
 +    return WINED3D_OK;
 +}
 diff --git a/dlls/wined3d/cs.c b/dlls/wined3d/cs.c
-index 6697cff..f4ea41c 100644
+index 6697cff3cc..f4ea41cf53 100644
 --- a/dlls/wined3d/cs.c
 +++ b/dlls/wined3d/cs.c
 @@ -465,6 +465,15 @@ static void wined3d_cs_exec_present(struct wined3d_cs *cs, const void *data)
@@ -563,7 +563,7 @@ index 6697cff..f4ea41c 100644
  
  void wined3d_cs_emit_present(struct wined3d_cs *cs, struct wined3d_swapchain *swapchain,
 diff --git a/dlls/wined3d/device.c b/dlls/wined3d/device.c
-index c3f5e09..57958da 100644
+index cd37be40d7..8c10e762f7 100644
 --- a/dlls/wined3d/device.c
 +++ b/dlls/wined3d/device.c
 @@ -840,6 +840,53 @@ static void destroy_default_samplers(struct wined3d_device *device, struct wined
@@ -629,7 +629,7 @@ index c3f5e09..57958da 100644
      context_release(context);
  
      while (device->context_count)
-@@ -1052,6 +1101,9 @@ static void wined3d_device_create_primary_opengl_context_cs(void *object)
+@@ -1053,6 +1102,9 @@ static void wined3d_device_create_primary_opengl_context_cs(void *object)
      context = context_acquire(device, target, 0);
      create_dummy_textures(device, context);
      create_default_samplers(device, context);
@@ -640,7 +640,7 @@ index c3f5e09..57958da 100644
  }
  
 diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
-index d55d567..eabdb65 100644
+index d55d5674f4..eabdb658b4 100644
 --- a/dlls/wined3d/directx.c
 +++ b/dlls/wined3d/directx.c
 @@ -111,6 +111,7 @@ static const struct wined3d_extension_map gl_extension_map[] =
@@ -661,7 +661,7 @@ index d55d567..eabdb65 100644
      USE_GL_FUNC(glClearBufferData)
      USE_GL_FUNC(glClearBufferSubData)
 diff --git a/dlls/wined3d/query.c b/dlls/wined3d/query.c
-index 5ea79b6..f3ca163 100644
+index 5ea79b6e4a..f3ca1630e5 100644
 --- a/dlls/wined3d/query.c
 +++ b/dlls/wined3d/query.c
 @@ -88,7 +88,7 @@ static BOOL wined3d_fence_supported(const struct wined3d_gl_info *gl_info)
@@ -674,7 +674,7 @@ index 5ea79b6..f3ca163 100644
  {
      const struct wined3d_gl_info *gl_info;
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
-index bbee788..730eff1 100644
+index bbee7881f2..730eff131f 100644
 --- a/dlls/wined3d/wined3d_gl.h
 +++ b/dlls/wined3d/wined3d_gl.h
 @@ -44,6 +44,7 @@ enum wined3d_gl_extension
@@ -686,7 +686,7 @@ index bbee788..730eff1 100644
      ARB_CLEAR_TEXTURE,
      ARB_CLIP_CONTROL,
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
-index 3c183a1..ee52801 100644
+index 8001062b0b..18afa8b5fe 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
 @@ -1712,6 +1712,9 @@ void wined3d_fence_destroy(struct wined3d_fence *fence) DECLSPEC_HIDDEN;
@@ -699,7 +699,7 @@ index 3c183a1..ee52801 100644
  
  /* Direct3D terminology with little modifications. We do not have an issued
   * state because only the driver knows about it, but we have a created state
-@@ -2980,6 +2983,10 @@ struct wined3d_device
+@@ -2988,6 +2991,10 @@ struct wined3d_device
      /* Context management */
      struct wined3d_context **contexts;
      UINT context_count;
@@ -710,7 +710,7 @@ index 3c183a1..ee52801 100644
  };
  
  void device_clear_render_targets(struct wined3d_device *device, UINT rt_count, const struct wined3d_fb_state *fb,
-@@ -3480,6 +3487,12 @@ void state_init(struct wined3d_state *state, struct wined3d_fb_state *fb,
+@@ -3492,6 +3499,12 @@ void state_init(struct wined3d_state *state, struct wined3d_fb_state *fb,
          DWORD flags) DECLSPEC_HIDDEN;
  void state_unbind_resources(struct wined3d_state *state) DECLSPEC_HIDDEN;
  
@@ -723,7 +723,7 @@ index 3c183a1..ee52801 100644
  enum wined3d_cs_queue_id
  {
      WINED3D_CS_QUEUE_DEFAULT = 0,
-@@ -3657,12 +3670,61 @@ enum wined3d_buffer_conversion_type
+@@ -3669,12 +3682,61 @@ enum wined3d_buffer_conversion_type
      CONV_POSITIONT,
  };
  
@@ -789,5 +789,5 @@ index 3c183a1..ee52801 100644
  {
      struct wined3d_resource resource;
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0001-wined3d-Initial-implementation-of-a-persistent-mappe.patch
+++ b/patches/0001-wined3d-Initial-implementation-of-a-persistent-mappe.patch
@@ -1,7 +1,7 @@
 From da3cbbdc792eef0783442c1b7baae3db9e6a528d Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:16:11 +0100
-Subject: [PATCH 1/9] wined3d: Initial implementation of a persistent mapped
+Subject: [PATCH 1/10] wined3d: Initial implementation of a persistent mapped
  buffer allocator.
 
 ---

--- a/patches/0002-wined3d-Add-support-for-backing-dynamic-wined3d_buff.patch
+++ b/patches/0002-wined3d-Add-support-for-backing-dynamic-wined3d_buff.patch
@@ -1,22 +1,22 @@
-From a50e63bd066afa3f6d944ef8c13fb0e415b20842 Mon Sep 17 00:00:00 2001
+From c1b5e8b6947555c8d20268847ffde1d475de2796 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:18:14 +0100
-Subject: [PATCH 2/10] wined3d: Add support for backing dynamic wined3d_buffer
+Date: Mon, 5 Mar 2018 15:39:11 -0800
+Subject: [PATCH 02/10] wined3d: Add support for backing dynamic wined3d_buffer
  objects by a persistent map.
 
 ---
- dlls/wined3d/buffer.c          | 220 ++++++++++++++++++++++++++++++++++++++++-
+ dlls/wined3d/buffer.c          | 220 ++++++++++++++++++++++++++++++++-
  dlls/wined3d/context.c         |   6 +-
- dlls/wined3d/cs.c              |  60 ++++++++++-
- dlls/wined3d/resource.c        |  18 +++-
- dlls/wined3d/state.c           |  17 +++-
- dlls/wined3d/texture.c         |  13 +++
+ dlls/wined3d/cs.c              |  60 ++++++++-
+ dlls/wined3d/resource.c        |  18 ++-
+ dlls/wined3d/state.c           |  17 ++-
+ dlls/wined3d/texture.c         |  13 ++
  dlls/wined3d/utils.c           |   1 +
- dlls/wined3d/wined3d_private.h |  11 +++
+ dlls/wined3d/wined3d_private.h |  11 ++
  8 files changed, 336 insertions(+), 10 deletions(-)
 
 diff --git a/dlls/wined3d/buffer.c b/dlls/wined3d/buffer.c
-index 3dec8d1..aee4b5b 100644
+index 2350661e36..40c454e466 100644
 --- a/dlls/wined3d/buffer.c
 +++ b/dlls/wined3d/buffer.c
 @@ -28,12 +28,14 @@
@@ -87,7 +87,7 @@ index 3dec8d1..aee4b5b 100644
  static BOOL buffer_process_converted_attribute(struct wined3d_buffer *buffer,
          const enum wined3d_buffer_conversion_type conversion_type,
          const struct wined3d_stream_info_element *attrib, DWORD *stride_this_run)
-@@ -631,6 +679,16 @@ static BOOL wined3d_buffer_prepare_location(struct wined3d_buffer *buffer,
+@@ -628,6 +676,16 @@ static BOOL wined3d_buffer_prepare_location(struct wined3d_buffer *buffer,
                  return FALSE;
              }
              return buffer_create_buffer_object(buffer, context);
@@ -104,7 +104,7 @@ index 3dec8d1..aee4b5b 100644
  
          default:
              ERR("Invalid location %s.\n", wined3d_debug_location(location));
-@@ -689,16 +747,32 @@ BOOL wined3d_buffer_load_location(struct wined3d_buffer *buffer,
+@@ -686,16 +744,32 @@ BOOL wined3d_buffer_load_location(struct wined3d_buffer *buffer,
                  buffer_conversion_upload(buffer, context);
              break;
  
@@ -138,7 +138,7 @@ index 3dec8d1..aee4b5b 100644
      return TRUE;
  }
  
-@@ -720,12 +794,25 @@ DWORD wined3d_buffer_get_memory(struct wined3d_buffer *buffer,
+@@ -717,12 +791,25 @@ DWORD wined3d_buffer_get_memory(struct wined3d_buffer *buffer,
      {
          data->buffer_object = buffer->buffer_object;
          data->addr = NULL;
@@ -164,7 +164,7 @@ index 3dec8d1..aee4b5b 100644
          return WINED3D_LOCATION_SYSMEM;
      }
  
-@@ -761,6 +848,8 @@ static void buffer_unload(struct wined3d_resource *resource)
+@@ -758,6 +845,8 @@ static void buffer_unload(struct wined3d_resource *resource)
          buffer->flags &= ~WINED3D_BUFFER_HASDESC;
      }
  
@@ -173,7 +173,7 @@ index 3dec8d1..aee4b5b 100644
      resource_unload(resource);
  }
  
-@@ -784,6 +873,8 @@ static void wined3d_buffer_destroy_object(void *object)
+@@ -781,6 +870,8 @@ static void wined3d_buffer_destroy_object(void *object)
          heap_free(buffer->conversion_map);
      }
  
@@ -182,7 +182,7 @@ index 3dec8d1..aee4b5b 100644
      heap_free(buffer->maps);
      heap_free(buffer);
  }
-@@ -900,6 +991,16 @@ void wined3d_buffer_load(struct wined3d_buffer *buffer, struct wined3d_context *
+@@ -897,6 +988,16 @@ void wined3d_buffer_load(struct wined3d_buffer *buffer, struct wined3d_context *
  
      buffer_mark_used(buffer);
  
@@ -199,7 +199,7 @@ index 3dec8d1..aee4b5b 100644
      /* TODO: Make converting independent from VBOs */
      if (!(buffer->flags & WINED3D_BUFFER_USE_BO))
      {
-@@ -1010,6 +1111,25 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
+@@ -1007,6 +1108,25 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
  
      count = ++buffer->resource.map_count;
  
@@ -225,7 +225,7 @@ index 3dec8d1..aee4b5b 100644
      if (buffer->buffer_object)
      {
          unsigned int dirty_offset = offset, dirty_size = size;
-@@ -1152,6 +1272,12 @@ static void wined3d_buffer_unmap(struct wined3d_buffer *buffer)
+@@ -1149,6 +1269,12 @@ static void wined3d_buffer_unmap(struct wined3d_buffer *buffer)
          return;
      }
  
@@ -238,7 +238,7 @@ index 3dec8d1..aee4b5b 100644
      if (buffer->map_ptr)
      {
          struct wined3d_device *device = buffer->resource.device;
-@@ -1254,6 +1380,64 @@ static void buffer_resource_preload(struct wined3d_resource *resource)
+@@ -1251,6 +1377,64 @@ static void buffer_resource_preload(struct wined3d_resource *resource)
  
  static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resource, unsigned int sub_resource_idx,
          struct wined3d_map_desc *map_desc, const struct wined3d_box *box, DWORD flags)
@@ -303,7 +303,7 @@ index 3dec8d1..aee4b5b 100644
  {
      struct wined3d_buffer *buffer = buffer_from_resource(resource);
      UINT offset, size;
-@@ -1297,6 +1481,18 @@ static HRESULT buffer_resource_sub_resource_map_info(struct wined3d_resource *re
+@@ -1294,6 +1478,18 @@ static HRESULT buffer_resource_sub_resource_map_info(struct wined3d_resource *re
  }
  
  static HRESULT buffer_resource_sub_resource_unmap(struct wined3d_resource *resource, unsigned int sub_resource_idx)
@@ -322,7 +322,7 @@ index 3dec8d1..aee4b5b 100644
  {
      if (sub_resource_idx)
      {
-@@ -1317,6 +1513,8 @@ static const struct wined3d_resource_ops buffer_resource_ops =
+@@ -1314,6 +1510,8 @@ static const struct wined3d_resource_ops buffer_resource_ops =
      buffer_resource_sub_resource_map,
      buffer_resource_sub_resource_map_info,
      buffer_resource_sub_resource_unmap,
@@ -364,10 +364,10 @@ index 3dec8d1..aee4b5b 100644
          TRACE("Not creating a BO because GL_ARB_vertex_buffer is not supported.\n");
      }
 diff --git a/dlls/wined3d/context.c b/dlls/wined3d/context.c
-index b0907cb..f547270 100644
+index f0f29d5dd0..ee8d485988 100644
 --- a/dlls/wined3d/context.c
 +++ b/dlls/wined3d/context.c
-@@ -4956,7 +4956,11 @@ void draw_primitive(struct wined3d_device *device, const struct wined3d_state *s
+@@ -4961,7 +4961,11 @@ void draw_primitive(struct wined3d_device *device, const struct wined3d_state *s
      if (parameters->indexed)
      {
          struct wined3d_buffer *index_buffer = state->index_buffer;
@@ -381,7 +381,7 @@ index b0907cb..f547270 100644
              idx_data = index_buffer->resource.heap_memory;
          }
 diff --git a/dlls/wined3d/cs.c b/dlls/wined3d/cs.c
-index f4ea41c..950b3f7 100644
+index f4ea41cf53..950b3f7f20 100644
 --- a/dlls/wined3d/cs.c
 +++ b/dlls/wined3d/cs.c
 @@ -73,6 +73,7 @@ enum wined3d_cs_op
@@ -487,10 +487,10 @@ index f4ea41c..950b3f7 100644
  
  static BOOL wined3d_cs_st_check_space(struct wined3d_cs *cs, size_t size, enum wined3d_cs_queue_id queue_id)
 diff --git a/dlls/wined3d/resource.c b/dlls/wined3d/resource.c
-index 61c7091..6a8d802 100644
+index df73997c84..7060d71613 100644
 --- a/dlls/wined3d/resource.c
 +++ b/dlls/wined3d/resource.c
-@@ -340,6 +340,7 @@ static DWORD wined3d_resource_sanitise_map_flags(const struct wined3d_resource *
+@@ -334,6 +334,7 @@ static DWORD wined3d_resource_sanitise_map_flags(const struct wined3d_resource *
  HRESULT CDECL wined3d_resource_map(struct wined3d_resource *resource, unsigned int sub_resource_idx,
          struct wined3d_map_desc *map_desc, const struct wined3d_box *box, DWORD flags)
  {
@@ -498,7 +498,7 @@ index 61c7091..6a8d802 100644
      TRACE("resource %p, sub_resource_idx %u, map_desc %p, box %s, flags %#x.\n",
              resource, sub_resource_idx, map_desc, debug_box(box), flags);
  
-@@ -362,9 +363,14 @@ HRESULT CDECL wined3d_resource_map(struct wined3d_resource *resource, unsigned i
+@@ -356,9 +357,14 @@ HRESULT CDECL wined3d_resource_map(struct wined3d_resource *resource, unsigned i
      }
  
      flags = wined3d_resource_sanitise_map_flags(resource, flags);
@@ -515,7 +515,7 @@ index 61c7091..6a8d802 100644
  }
  
  HRESULT CDECL wined3d_resource_map_info(struct wined3d_resource *resource, unsigned int sub_resource_idx,
-@@ -377,9 +383,15 @@ HRESULT CDECL wined3d_resource_map_info(struct wined3d_resource *resource, unsig
+@@ -371,9 +377,15 @@ HRESULT CDECL wined3d_resource_map_info(struct wined3d_resource *resource, unsig
  
  HRESULT CDECL wined3d_resource_unmap(struct wined3d_resource *resource, unsigned int sub_resource_idx)
  {
@@ -533,7 +533,7 @@ index 61c7091..6a8d802 100644
  
  UINT CDECL wined3d_resource_update_info(struct wined3d_resource *resource, unsigned int sub_resource_idx,
 diff --git a/dlls/wined3d/state.c b/dlls/wined3d/state.c
-index 93ee02a..c9cb416 100644
+index 93ee02aadb..c9cb416af8 100644
 --- a/dlls/wined3d/state.c
 +++ b/dlls/wined3d/state.c
 @@ -4797,7 +4797,11 @@ static void indexbuffer(struct wined3d_context *context, const struct wined3d_st
@@ -575,10 +575,10 @@ index 93ee02a..c9cb416 100644
      checkGLcall("bind constant buffers");
  }
 diff --git a/dlls/wined3d/texture.c b/dlls/wined3d/texture.c
-index 6a4a1c4..cffadeb 100644
+index bd7b16f134..58f10d5545 100644
 --- a/dlls/wined3d/texture.c
 +++ b/dlls/wined3d/texture.c
-@@ -2095,6 +2095,12 @@ static void wined3d_texture_unload(struct wined3d_resource *resource)
+@@ -2216,6 +2216,12 @@ static void wined3d_texture_unload(struct wined3d_resource *resource)
  
  static HRESULT texture_resource_sub_resource_map(struct wined3d_resource *resource, unsigned int sub_resource_idx,
          struct wined3d_map_desc *map_desc, const struct wined3d_box *box, DWORD flags)
@@ -591,7 +591,7 @@ index 6a4a1c4..cffadeb 100644
  {
      const struct wined3d_format *format = resource->format;
      struct wined3d_texture_sub_resource *sub_resource;
-@@ -2255,6 +2261,11 @@ static HRESULT texture_resource_sub_resource_map_info(struct wined3d_resource *r
+@@ -2376,6 +2382,11 @@ static HRESULT texture_resource_sub_resource_map_info(struct wined3d_resource *r
  }
  
  static HRESULT texture_resource_sub_resource_unmap(struct wined3d_resource *resource, unsigned int sub_resource_idx)
@@ -603,7 +603,7 @@ index 6a4a1c4..cffadeb 100644
  {
      struct wined3d_texture_sub_resource *sub_resource;
      struct wined3d_device *device = resource->device;
-@@ -2307,6 +2318,8 @@ static const struct wined3d_resource_ops texture_resource_ops =
+@@ -2428,6 +2439,8 @@ static const struct wined3d_resource_ops texture_resource_ops =
      texture_resource_sub_resource_map,
      texture_resource_sub_resource_map_info,
      texture_resource_sub_resource_unmap,
@@ -613,7 +613,7 @@ index 6a4a1c4..cffadeb 100644
  
  /* Context activation is done by the caller. */
 diff --git a/dlls/wined3d/utils.c b/dlls/wined3d/utils.c
-index 23017e6..8d91973 100644
+index 23017e6fbf..8d91973c57 100644
 --- a/dlls/wined3d/utils.c
 +++ b/dlls/wined3d/utils.c
 @@ -6321,6 +6321,7 @@ const char *wined3d_debug_location(DWORD location)
@@ -625,7 +625,7 @@ index 23017e6..8d91973 100644
      if (location)
          FIXME("Unrecognized location flag(s) %#x.\n", location);
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
-index ee52801..932c4b7 100644
+index 18afa8b5fe..0440f887c1 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
 @@ -1470,6 +1470,7 @@ struct wined3d_bo_address
@@ -636,7 +636,7 @@ index ee52801..932c4b7 100644
  };
  
  struct wined3d_const_bo_address
-@@ -3028,6 +3029,9 @@ struct wined3d_resource_ops
+@@ -3036,6 +3037,9 @@ struct wined3d_resource_ops
      HRESULT (*resource_map_info)(struct wined3d_resource *resource, unsigned int sub_resource_idx,
              struct wined3d_map_info *info, DWORD flags);
      HRESULT (*resource_sub_resource_unmap)(struct wined3d_resource *resource, unsigned int sub_resource_idx);
@@ -646,7 +646,7 @@ index ee52801..932c4b7 100644
  };
  
  struct wined3d_resource
-@@ -3331,6 +3335,7 @@ void wined3d_texture_validate_location(struct wined3d_texture *texture,
+@@ -3347,6 +3351,7 @@ void wined3d_texture_validate_location(struct wined3d_texture *texture,
  #define WINED3D_LOCATION_DRAWABLE       0x00000040
  #define WINED3D_LOCATION_RB_MULTISAMPLE 0x00000080
  #define WINED3D_LOCATION_RB_RESOLVED    0x00000100
@@ -654,7 +654,7 @@ index ee52801..932c4b7 100644
  
  const char *wined3d_debug_location(DWORD location) DECLSPEC_HIDDEN;
  
-@@ -3637,6 +3642,7 @@ void wined3d_cs_emit_unload_resource(struct wined3d_cs *cs, struct wined3d_resou
+@@ -3649,6 +3654,7 @@ void wined3d_cs_emit_unload_resource(struct wined3d_cs *cs, struct wined3d_resou
  void wined3d_cs_emit_update_sub_resource(struct wined3d_cs *cs, struct wined3d_resource *resource,
          unsigned int sub_resource_idx, const struct wined3d_box *box, const void *data, unsigned int row_pitch,
          unsigned int slice_pitch) DECLSPEC_HIDDEN;
@@ -662,7 +662,7 @@ index ee52801..932c4b7 100644
  void wined3d_cs_init_object(struct wined3d_cs *cs,
          void (*callback)(void *object), void *object) DECLSPEC_HIDDEN;
  HRESULT wined3d_cs_map(struct wined3d_cs *cs, struct wined3d_resource *resource, unsigned int sub_resource_idx,
-@@ -3749,6 +3755,11 @@ struct wined3d_buffer
+@@ -3761,6 +3767,11 @@ struct wined3d_buffer
      UINT stride;                                            /* 0 if no conversion */
      enum wined3d_buffer_conversion_type *conversion_map;    /* NULL if no conversion */
      UINT conversion_stride;                                 /* 0 if no shifted conversion */
@@ -675,5 +675,5 @@ index ee52801..932c4b7 100644
  
  static inline struct wined3d_buffer *buffer_from_resource(struct wined3d_resource *resource)
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0002-wined3d-Add-support-for-backing-dynamic-wined3d_buff.patch
+++ b/patches/0002-wined3d-Add-support-for-backing-dynamic-wined3d_buff.patch
@@ -1,7 +1,7 @@
 From a50e63bd066afa3f6d944ef8c13fb0e415b20842 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:18:14 +0100
-Subject: [PATCH 2/9] wined3d: Add support for backing dynamic wined3d_buffer
+Subject: [PATCH 2/10] wined3d: Add support for backing dynamic wined3d_buffer
  objects by a persistent map.
 
 ---

--- a/patches/0003-wined3d-Use-ARB_multi_bind-to-speed-up-UBO-updates.patch
+++ b/patches/0003-wined3d-Use-ARB_multi_bind-to-speed-up-UBO-updates.patch
@@ -1,16 +1,19 @@
-From 2850f4f78ee6f3b3e1dea4d692d527b49bb85b13 Mon Sep 17 00:00:00 2001
+From fa5c202d306e21934b4ad25bbc19a46062005413 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:18:59 +0100
-Subject: [PATCH 3/10] wined3d: Use ARB_multi_bind to speed up UBO updates.
+Date: Mon, 5 Mar 2018 20:28:34 -0800
+Subject: [PATCH 03/10] wined3d: Use ARB_multi_bind to speed up UBO updates.
 
+More frequent UBO remaps as a result of the persistent buffer allocator
+causes glBindBufferRange to be a bottleneck. Using ARB_multi_bind
+massively reduces state change overhead.
 ---
  dlls/wined3d/directx.c    |  4 ++++
- dlls/wined3d/state.c      | 46 +++++++++++++++++++++++++++++++++++++++-------
+ dlls/wined3d/state.c      | 46 +++++++++++++++++++++++++++++++++------
  dlls/wined3d/wined3d_gl.h |  1 +
  3 files changed, 44 insertions(+), 7 deletions(-)
 
 diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
-index eabdb65..2831baa 100644
+index eabdb658b4..2831baa1d7 100644
 --- a/dlls/wined3d/directx.c
 +++ b/dlls/wined3d/directx.c
 @@ -149,6 +149,7 @@ static const struct wined3d_extension_map gl_extension_map[] =
@@ -39,7 +42,7 @@ index eabdb65..2831baa 100644
          {ARB_CLIP_CONTROL,                 MAKEDWORD_VERSION(4, 5)},
          {ARB_CULL_DISTANCE,                MAKEDWORD_VERSION(4, 5)},
 diff --git a/dlls/wined3d/state.c b/dlls/wined3d/state.c
-index c9cb416..0afb5e8 100644
+index c9cb416af8..0afb5e81c9 100644
 --- a/dlls/wined3d/state.c
 +++ b/dlls/wined3d/state.c
 @@ -4877,19 +4877,51 @@ static void state_cb(struct wined3d_context *context, const struct wined3d_state
@@ -102,7 +105,7 @@ index c9cb416..0afb5e8 100644
  }
  
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
-index 730eff1..4ece45c 100644
+index 730eff131f..4ece45c26f 100644
 --- a/dlls/wined3d/wined3d_gl.h
 +++ b/dlls/wined3d/wined3d_gl.h
 @@ -82,6 +82,7 @@ enum wined3d_gl_extension
@@ -114,5 +117,5 @@ index 730eff1..4ece45c 100644
      ARB_MULTITEXTURE,
      ARB_OCCLUSION_QUERY,
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0003-wined3d-Use-ARB_multi_bind-to-speed-up-UBO-updates.patch
+++ b/patches/0003-wined3d-Use-ARB_multi_bind-to-speed-up-UBO-updates.patch
@@ -1,7 +1,7 @@
 From 2850f4f78ee6f3b3e1dea4d692d527b49bb85b13 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:18:59 +0100
-Subject: [PATCH 3/9] wined3d: Use ARB_multi_bind to speed up UBO updates.
+Subject: [PATCH 3/10] wined3d: Use ARB_multi_bind to speed up UBO updates.
 
 ---
  dlls/wined3d/directx.c    |  4 ++++

--- a/patches/0004-wined3d-Use-GL_CLIENT_STORAGE_BIT-for-persistent-map.patch
+++ b/patches/0004-wined3d-Use-GL_CLIENT_STORAGE_BIT-for-persistent-map.patch
@@ -1,7 +1,7 @@
 From 56b69bee4b15f4a83565c8e1a2b4d063e90d1a5f Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:19:36 +0100
-Subject: [PATCH 4/9] wined3d: Use GL_CLIENT_STORAGE_BIT for persistent
+Subject: [PATCH 4/10] wined3d: Use GL_CLIENT_STORAGE_BIT for persistent
  mappings.
 
 ---

--- a/patches/0004-wined3d-Use-GL_CLIENT_STORAGE_BIT-for-persistent-map.patch
+++ b/patches/0004-wined3d-Use-GL_CLIENT_STORAGE_BIT-for-persistent-map.patch
@@ -1,7 +1,7 @@
-From 56b69bee4b15f4a83565c8e1a2b4d063e90d1a5f Mon Sep 17 00:00:00 2001
+From e4ff5b362efbe23e4a0a51adec07fb69eb1c507c Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:19:36 +0100
-Subject: [PATCH 4/10] wined3d: Use GL_CLIENT_STORAGE_BIT for persistent
+Date: Tue, 6 Mar 2018 02:07:31 -0800
+Subject: [PATCH 04/10] wined3d: Use GL_CLIENT_STORAGE_BIT for persistent
  mappings.
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 4/10] wined3d: Use GL_CLIENT_STORAGE_BIT for persistent
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
-index b133bd6..75f84b0 100644
+index b133bd6893..75f84b0088 100644
 --- a/dlls/wined3d/buffer_heap.c
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -169,7 +169,7 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
@@ -22,5 +22,5 @@ index b133bd6..75f84b0 100644
      // TODO(acomminos): where should we be checking for errors here?
      GL_EXTCALL(glGenBuffers(1, &object->buffer_object));
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0005-wined3d-Disable-persistently-mapped-shader-resource-.patch
+++ b/patches/0005-wined3d-Disable-persistently-mapped-shader-resource-.patch
@@ -1,7 +1,7 @@
-From 78a493953e501224ba2e7e9451e9c3562a6e1eb8 Mon Sep 17 00:00:00 2001
+From 7d0bee6eb5e3fc0010407c4c7bc9ccd23196d050 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:20:03 +0100
-Subject: [PATCH 5/10] wined3d: Disable persistently mapped shader resource
+Date: Thu, 8 Mar 2018 22:00:33 -0800
+Subject: [PATCH 05/10] wined3d: Disable persistently mapped shader resource
  buffers.
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 5/10] wined3d: Disable persistently mapped shader resource
  1 file changed, 4 insertions(+)
 
 diff --git a/dlls/wined3d/buffer.c b/dlls/wined3d/buffer.c
-index aee4b5b..31dd88e 100644
+index 40c454e466..5933481613 100644
 --- a/dlls/wined3d/buffer.c
 +++ b/dlls/wined3d/buffer.c
 @@ -1596,6 +1596,10 @@ static HRESULT buffer_init(struct wined3d_buffer *buffer, struct wined3d_device
@@ -24,5 +24,5 @@ index aee4b5b..31dd88e 100644
          {
              // If supported, use persistent mapped buffers instead of a
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0005-wined3d-Disable-persistently-mapped-shader-resource-.patch
+++ b/patches/0005-wined3d-Disable-persistently-mapped-shader-resource-.patch
@@ -1,7 +1,7 @@
 From 78a493953e501224ba2e7e9451e9c3562a6e1eb8 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:20:03 +0100
-Subject: [PATCH 5/9] wined3d: Disable persistently mapped shader resource
+Subject: [PATCH 5/10] wined3d: Disable persistently mapped shader resource
  buffers.
 
 ---

--- a/patches/0006-wined3d-Perform-initial-allocation-of-persistent-buf.patch
+++ b/patches/0006-wined3d-Perform-initial-allocation-of-persistent-buf.patch
@@ -1,7 +1,7 @@
 From 8fda4d7847d610a30e9e9c258ce30bada3c6320b Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:23:00 +0100
-Subject: [PATCH 6/9] wined3d: Perform initial allocation of persistent buffers
+Subject: [PATCH 6/10] wined3d: Perform initial allocation of persistent buffers
  asynchronously.
 
 ---

--- a/patches/0006-wined3d-Perform-initial-allocation-of-persistent-buf.patch
+++ b/patches/0006-wined3d-Perform-initial-allocation-of-persistent-buf.patch
@@ -1,15 +1,15 @@
-From 8fda4d7847d610a30e9e9c258ce30bada3c6320b Mon Sep 17 00:00:00 2001
+From 7c34148f442defe9b3212f93ab85fcc4255f14d6 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:23:00 +0100
-Subject: [PATCH 6/10] wined3d: Perform initial allocation of persistent buffers
- asynchronously.
+Date: Thu, 8 Mar 2018 22:42:03 -0800
+Subject: [PATCH 06/10] wined3d: Perform initial allocation of persistent
+ buffers asynchronously.
 
 ---
  dlls/wined3d/buffer.c | 30 ++++++++++++++++++++----------
  1 file changed, 20 insertions(+), 10 deletions(-)
 
 diff --git a/dlls/wined3d/buffer.c b/dlls/wined3d/buffer.c
-index 31dd88e..3c44a5b 100644
+index 5933481613..825a796db1 100644
 --- a/dlls/wined3d/buffer.c
 +++ b/dlls/wined3d/buffer.c
 @@ -272,7 +272,7 @@ fail:
@@ -21,7 +21,7 @@ index 31dd88e..3c44a5b 100644
  {
      struct wined3d_device *device = buffer->resource.device;
      struct wined3d_buffer_heap *heap;
-@@ -688,7 +688,7 @@ static BOOL wined3d_buffer_prepare_location(struct wined3d_buffer *buffer,
+@@ -685,7 +685,7 @@ static BOOL wined3d_buffer_prepare_location(struct wined3d_buffer *buffer,
                  WARN("Trying to map a persistent region for buffer %p without WINED3D_BUFFER_PERSISTENT.\n", buffer);
                  return FALSE;
              }
@@ -30,7 +30,7 @@ index 31dd88e..3c44a5b 100644
  
          default:
              ERR("Invalid location %s.\n", wined3d_debug_location(location));
-@@ -1116,7 +1116,7 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
+@@ -1113,7 +1113,7 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
          const struct wined3d_gl_info *gl_info;
          context = context_acquire(device, NULL, 0);
  
@@ -39,7 +39,7 @@ index 31dd88e..3c44a5b 100644
  
          gl_info = context->gl_info;
          gl_info->gl_ops.gl.p_glFinish();
-@@ -1392,8 +1392,20 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
+@@ -1389,8 +1389,20 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
  
      // Support immediate mapping of persistent buffers off the command thread,
      // which require no GL calls to interface with.
@@ -61,7 +61,7 @@ index 31dd88e..3c44a5b 100644
          map_desc->row_pitch = map_desc->slice_pitch = buffer->desc.byte_width;
          if (flags & WINED3D_MAP_DISCARD)
          {
-@@ -1413,6 +1425,7 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
+@@ -1410,6 +1422,7 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
              // currently used buffer to the free pool, along with the fence that
              // must be called before the buffer can be reused.
              wined3d_cs_emit_discard_buffer(resource->device->cs, buffer, map_range);
@@ -69,7 +69,7 @@ index 31dd88e..3c44a5b 100644
              return WINED3D_OK;
          }
          else if (flags & WINED3D_MAP_NOOVERWRITE)
-@@ -1423,14 +1436,11 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
+@@ -1420,14 +1433,11 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
              struct wined3d_map_range map_range = buffer->mt_persistent_map;
              map_desc->data = buffer->buffer_heap->map_ptr + map_range.offset + offset;
              resource->map_count++;
@@ -88,5 +88,5 @@ index 31dd88e..3c44a5b 100644
  
      return E_NOTIMPL;
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0007-wined3d-Avoid-freeing-persistent-buffer-heap-element.patch
+++ b/patches/0007-wined3d-Avoid-freeing-persistent-buffer-heap-element.patch
@@ -1,21 +1,21 @@
-From f2aabf49eef0e432cd96cac90ed27af12c46a110 Mon Sep 17 00:00:00 2001
+From 8608508b1e3e2665b1f1b4ded302de1d32590d5d Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:23:43 +0100
-Subject: [PATCH 7/10] wined3d: Avoid freeing persistent buffer heap elements
+Date: Thu, 8 Mar 2018 23:01:50 -0800
+Subject: [PATCH 07/10] wined3d: Avoid freeing persistent buffer heap elements
  during use.
 
 Using HeapFree is expensive, especially when we don't have our buffers
 for long.
 ---
- dlls/wined3d/buffer.c          | 29 +++++++++++----------
- dlls/wined3d/buffer_heap.c     | 57 ++++++++++++++++++------------------------
+ dlls/wined3d/buffer.c          | 29 +++++++++--------
+ dlls/wined3d/buffer_heap.c     | 57 ++++++++++++++--------------------
  dlls/wined3d/context.c         |  4 +--
- dlls/wined3d/cs.c              |  6 ++---
- dlls/wined3d/wined3d_private.h | 25 ++++++++++++------
+ dlls/wined3d/cs.c              |  6 ++--
+ dlls/wined3d/wined3d_private.h | 25 ++++++++++-----
  5 files changed, 61 insertions(+), 60 deletions(-)
 
 diff --git a/dlls/wined3d/buffer.c b/dlls/wined3d/buffer.c
-index 3c44a5b..4eaa6c7 100644
+index 825a796db1..533befd2fcb 100644
 --- a/dlls/wined3d/buffer.c
 +++ b/dlls/wined3d/buffer.c
 @@ -276,7 +276,7 @@ static BOOL buffer_alloc_persistent_map(struct wined3d_buffer *buffer)
@@ -43,7 +43,7 @@ index 3c44a5b..4eaa6c7 100644
      return TRUE;
  
  fail:
-@@ -753,7 +753,7 @@ BOOL wined3d_buffer_load_location(struct wined3d_buffer *buffer,
+@@ -750,7 +750,7 @@ BOOL wined3d_buffer_load_location(struct wined3d_buffer *buffer,
              if (buffer->conversion_map)
                  FIXME("Attempting to use conversion map with persistent mapping.\n");
              memcpy(buffer->buffer_heap->map_ptr +
@@ -52,7 +52,7 @@ index 3c44a5b..4eaa6c7 100644
                     buffer->resource.heap_memory, buffer->resource.size);
              break;
  
-@@ -801,11 +801,11 @@ DWORD wined3d_buffer_get_memory(struct wined3d_buffer *buffer,
+@@ -798,11 +798,11 @@ DWORD wined3d_buffer_get_memory(struct wined3d_buffer *buffer,
      {
          // FIXME(acomminos): should we expose a buffer object we don't wholly own here?
          data->buffer_object = buffer->buffer_heap->buffer_object;
@@ -66,7 +66,7 @@ index 3c44a5b..4eaa6c7 100644
          return WINED3D_LOCATION_PERSISTENT_MAP;
      }
      if (locations & WINED3D_LOCATION_SYSMEM)
-@@ -1122,7 +1122,7 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
+@@ -1119,7 +1119,7 @@ static HRESULT wined3d_buffer_map(struct wined3d_buffer *buffer, UINT offset, UI
          gl_info->gl_ops.gl.p_glFinish();
  
          base = buffer->buffer_heap->map_ptr
@@ -75,7 +75,7 @@ index 3c44a5b..4eaa6c7 100644
          *data = base + offset;
  
          context_release(context);
-@@ -1410,22 +1410,21 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
+@@ -1407,22 +1407,21 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
          if (flags & WINED3D_MAP_DISCARD)
          {
              HRESULT hr;
@@ -103,7 +103,7 @@ index 3c44a5b..4eaa6c7 100644
              return WINED3D_OK;
          }
          else if (flags & WINED3D_MAP_NOOVERWRITE)
-@@ -1433,7 +1432,7 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
+@@ -1430,7 +1429,7 @@ static HRESULT buffer_resource_sub_resource_map(struct wined3d_resource *resourc
              // Allow immediate access for persistent buffers without a fence.
              // Always use the latest buffer in this case in case the latest
              // DISCARDed one hasn't reached the command stream yet.
@@ -113,7 +113,7 @@ index 3c44a5b..4eaa6c7 100644
              resource->map_count++;
  
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
-index 75f84b0..80670c5 100644
+index 75f84b0088..80670c515f 100644
 --- a/dlls/wined3d/buffer_heap.c
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -25,18 +25,6 @@
@@ -235,10 +235,10 @@ index 75f84b0..80670c5 100644
      struct wined3d_buffer_heap_bin *bin = &heap->pending_fenced_bins.bins[bin_index];
  
 diff --git a/dlls/wined3d/context.c b/dlls/wined3d/context.c
-index f547270..102d953 100644
+index ee8d485988..bfe7c71b3f 100644
 --- a/dlls/wined3d/context.c
 +++ b/dlls/wined3d/context.c
-@@ -4956,9 +4956,9 @@ void draw_primitive(struct wined3d_device *device, const struct wined3d_state *s
+@@ -4961,9 +4961,9 @@ void draw_primitive(struct wined3d_device *device, const struct wined3d_state *s
      if (parameters->indexed)
      {
          struct wined3d_buffer *index_buffer = state->index_buffer;
@@ -251,7 +251,7 @@ index f547270..102d953 100644
          else if (!index_buffer->buffer_object || !stream_info->all_vbo)
          {
 diff --git a/dlls/wined3d/cs.c b/dlls/wined3d/cs.c
-index 950b3f7..fdd9e44 100644
+index 950b3f7f20..fdd9e44b07 100644
 --- a/dlls/wined3d/cs.c
 +++ b/dlls/wined3d/cs.c
 @@ -442,7 +442,7 @@ struct wined3d_cs_discard_buffer
@@ -281,10 +281,10 @@ index 950b3f7..fdd9e44 100644
      wined3d_resource_acquire(&buffer->resource);
  
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
-index 932c4b7..88233a3 100644
+index 0440f887c1..43b6623af0 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
-@@ -3498,6 +3498,18 @@ struct wined3d_map_range
+@@ -3510,6 +3510,18 @@ struct wined3d_map_range
      GLsizeiptr size;
  };
  
@@ -303,7 +303,7 @@ index 932c4b7..88233a3 100644
  enum wined3d_cs_queue_id
  {
      WINED3D_CS_QUEUE_DEFAULT = 0,
-@@ -3642,7 +3654,7 @@ void wined3d_cs_emit_unload_resource(struct wined3d_cs *cs, struct wined3d_resou
+@@ -3654,7 +3666,7 @@ void wined3d_cs_emit_unload_resource(struct wined3d_cs *cs, struct wined3d_resou
  void wined3d_cs_emit_update_sub_resource(struct wined3d_cs *cs, struct wined3d_resource *resource,
          unsigned int sub_resource_idx, const struct wined3d_box *box, const void *data, unsigned int row_pitch,
          unsigned int slice_pitch) DECLSPEC_HIDDEN;
@@ -312,7 +312,7 @@ index 932c4b7..88233a3 100644
  void wined3d_cs_init_object(struct wined3d_cs *cs,
          void (*callback)(void *object), void *object) DECLSPEC_HIDDEN;
  HRESULT wined3d_cs_map(struct wined3d_cs *cs, struct wined3d_resource *resource, unsigned int sub_resource_idx,
-@@ -3676,7 +3688,6 @@ enum wined3d_buffer_conversion_type
+@@ -3688,7 +3700,6 @@ enum wined3d_buffer_conversion_type
      CONV_POSITIONT,
  };
  
@@ -320,7 +320,7 @@ index 932c4b7..88233a3 100644
  struct wined3d_buffer_heap_fenced_element;
  
  // Number of power-of-two buckets to populate.
-@@ -3715,11 +3726,11 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
+@@ -3727,11 +3738,11 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
  HRESULT wined3d_buffer_heap_destroy(struct wined3d_buffer_heap *heap, struct wined3d_context *context) DECLSPEC_HIDDEN;
  // Fetches a buffer from the heap of at least the given size.
  // Attempts to coalesce blocks under memory pressure.
@@ -335,7 +335,7 @@ index 932c4b7..88233a3 100644
  // Issues a fence for the current set of pending fenced buffers.
  // Double-buffered: if the last fence issued has not yet been triggered, waits
  // on it.
-@@ -3758,8 +3769,8 @@ struct wined3d_buffer
+@@ -3770,8 +3781,8 @@ struct wined3d_buffer
  
      /* persistent mapped buffer */
      struct wined3d_buffer_heap *buffer_heap;
@@ -347,5 +347,5 @@ index 932c4b7..88233a3 100644
  
  static inline struct wined3d_buffer *buffer_from_resource(struct wined3d_resource *resource)
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0007-wined3d-Avoid-freeing-persistent-buffer-heap-element.patch
+++ b/patches/0007-wined3d-Avoid-freeing-persistent-buffer-heap-element.patch
@@ -1,7 +1,7 @@
 From f2aabf49eef0e432cd96cac90ed27af12c46a110 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:23:43 +0100
-Subject: [PATCH 7/9] wined3d: Avoid freeing persistent buffer heap elements
+Subject: [PATCH 7/10] wined3d: Avoid freeing persistent buffer heap elements
  during use.
 
 Using HeapFree is expensive, especially when we don't have our buffers

--- a/patches/0008-wined3d-Add-DISABLE_PBA-envvar-some-PBA-cleanup.patch
+++ b/patches/0008-wined3d-Add-DISABLE_PBA-envvar-some-PBA-cleanup.patch
@@ -1,18 +1,18 @@
-From b4f47f3b6be1ea3fb92cadc06f608c0b51d0e454 Mon Sep 17 00:00:00 2001
+From 85218da9bb89fa1a7b5c74e14d62ac610088d6ed Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:28:50 +0100
-Subject: [PATCH 8/10] wined3d: Add DISABLE_PBA envvar, some PBA cleanup.
+Date: Thu, 15 Mar 2018 21:07:21 -0700
+Subject: [PATCH 08/10] wined3d: Add DISABLE_PBA envvar, some PBA cleanup.
 
 ---
  dlls/wined3d/buffer.c          |  4 ++--
- dlls/wined3d/buffer_heap.c     | 34 ++++++++++++++++++++++++++--------
- dlls/wined3d/device.c          | 38 ++++++++++++++++++++++++++------------
+ dlls/wined3d/buffer_heap.c     | 34 +++++++++++++++++++++++-------
+ dlls/wined3d/device.c          | 38 +++++++++++++++++++++++-----------
  dlls/wined3d/query.c           |  2 +-
  dlls/wined3d/wined3d_private.h |  6 ++----
  5 files changed, 57 insertions(+), 27 deletions(-)
 
 diff --git a/dlls/wined3d/buffer.c b/dlls/wined3d/buffer.c
-index 4eaa6c7..c3d65b8 100644
+index 533befd2fcb..3a56d9c9a3 100644
 --- a/dlls/wined3d/buffer.c
 +++ b/dlls/wined3d/buffer.c
 @@ -1601,9 +1601,9 @@ static HRESULT buffer_init(struct wined3d_buffer *buffer, struct wined3d_device
@@ -28,7 +28,7 @@ index 4eaa6c7..c3d65b8 100644
          else if (bind_flags & WINED3D_BIND_SHADER_RESOURCE)
          {
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
-index 80670c5..899aad9 100644
+index 80670c515f..899aad9612 100644
 --- a/dlls/wined3d/buffer_heap.c
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -25,6 +25,9 @@
@@ -104,7 +104,7 @@ index 80670c5..899aad9 100644
  }
  
 diff --git a/dlls/wined3d/device.c b/dlls/wined3d/device.c
-index 57958da..9a8bade 100644
+index 8c10e762f7..098e04ef1c 100644
 --- a/dlls/wined3d/device.c
 +++ b/dlls/wined3d/device.c
 @@ -844,16 +844,27 @@ static void destroy_default_samplers(struct wined3d_device *device, struct wined
@@ -171,7 +171,7 @@ index 57958da..9a8bade 100644
  
  /* Context activation is done by the caller. */
 diff --git a/dlls/wined3d/query.c b/dlls/wined3d/query.c
-index f3ca163..5ea79b6 100644
+index f3ca1630e5..5ea79b6e4a 100644
 --- a/dlls/wined3d/query.c
 +++ b/dlls/wined3d/query.c
 @@ -88,7 +88,7 @@ static BOOL wined3d_fence_supported(const struct wined3d_gl_info *gl_info)
@@ -184,7 +184,7 @@ index f3ca163..5ea79b6 100644
  {
      const struct wined3d_gl_info *gl_info;
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
-index 88233a3..25ffe45 100644
+index 43b6623af0..abd12c20eb 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
 @@ -1713,9 +1713,6 @@ void wined3d_fence_destroy(struct wined3d_fence *fence) DECLSPEC_HIDDEN;
@@ -197,7 +197,7 @@ index 88233a3..25ffe45 100644
  
  /* Direct3D terminology with little modifications. We do not have an issued
   * state because only the driver knows about it, but we have a created state
-@@ -2933,7 +2930,8 @@ struct wined3d_device
+@@ -2941,7 +2938,8 @@ struct wined3d_device
      BYTE inScene : 1;                   /* A flag to check for proper BeginScene / EndScene call pairs */
      BYTE softwareVertexProcessing : 1;  /* process vertex shaders using software or hardware */
      BYTE filter_messages : 1;
@@ -208,5 +208,5 @@ index 88233a3..25ffe45 100644
      unsigned char           surface_alignment; /* Line Alignment of surfaces                      */
  
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0008-wined3d-Add-DISABLE_PBA-envvar-some-PBA-cleanup.patch
+++ b/patches/0008-wined3d-Add-DISABLE_PBA-envvar-some-PBA-cleanup.patch
@@ -1,7 +1,7 @@
 From b4f47f3b6be1ea3fb92cadc06f608c0b51d0e454 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:28:50 +0100
-Subject: [PATCH 8/9] wined3d: Add DISABLE_PBA envvar, some PBA cleanup.
+Subject: [PATCH 8/10] wined3d: Add DISABLE_PBA envvar, some PBA cleanup.
 
 ---
  dlls/wined3d/buffer.c          |  4 ++--

--- a/patches/0009-wined3d-Add-quirk-to-use-GL_CLIENT_STORAGE_BIT-for-m.patch
+++ b/patches/0009-wined3d-Add-quirk-to-use-GL_CLIENT_STORAGE_BIT-for-m.patch
@@ -1,7 +1,7 @@
 From 7cb44d0e1788b232aeb8a3b73f243d80a726d150 Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
 Date: Sun, 1 Apr 2018 02:29:38 +0100
-Subject: [PATCH 9/9] wined3d: Add quirk to use GL_CLIENT_STORAGE_BIT for mesa.
+Subject: [PATCH 9/10] wined3d: Add quirk to use GL_CLIENT_STORAGE_BIT for mesa.
 
 ---
  dlls/wined3d/buffer_heap.c     | 15 ++++++++++++++-

--- a/patches/0009-wined3d-Add-quirk-to-use-GL_CLIENT_STORAGE_BIT-for-m.patch
+++ b/patches/0009-wined3d-Add-quirk-to-use-GL_CLIENT_STORAGE_BIT-for-m.patch
@@ -1,7 +1,8 @@
-From 7cb44d0e1788b232aeb8a3b73f243d80a726d150 Mon Sep 17 00:00:00 2001
+From 1a127456348da30c84ed1bd1d1d88c6a045f4d9c Mon Sep 17 00:00:00 2001
 From: Andrew Comminos <andrew@comminos.com>
-Date: Sun, 1 Apr 2018 02:29:38 +0100
-Subject: [PATCH 9/10] wined3d: Add quirk to use GL_CLIENT_STORAGE_BIT for mesa.
+Date: Thu, 15 Mar 2018 21:22:06 -0700
+Subject: [PATCH 09/10] wined3d: Add quirk to use GL_CLIENT_STORAGE_BIT for
+ mesa.
 
 ---
  dlls/wined3d/buffer_heap.c     | 15 ++++++++++++++-
@@ -10,7 +11,7 @@ Subject: [PATCH 9/10] wined3d: Add quirk to use GL_CLIENT_STORAGE_BIT for mesa.
  3 files changed, 34 insertions(+), 1 deletion(-)
 
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
-index 899aad9..9e8f2d7 100644
+index 899aad9612..9e8f2d799d 100644
 --- a/dlls/wined3d/buffer_heap.c
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -165,7 +165,20 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
@@ -36,7 +37,7 @@ index 899aad9..9e8f2d7 100644
      GL_EXTCALL(glGenBuffers(1, &object->buffer_object));
      checkGLcall("glGenBuffers");
 diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
-index 2831baa..ee0d4c7 100644
+index 2831baa1d7..ee0d4c7b2d 100644
 --- a/dlls/wined3d/directx.c
 +++ b/dlls/wined3d/directx.c
 @@ -946,6 +946,13 @@ static BOOL match_broken_viewport_subpixel_bits(const struct wined3d_gl_info *gl
@@ -80,7 +81,7 @@ index 2831baa..ee0d4c7 100644
  
  /* Certain applications (Steam) complain if we report an outdated driver version. In general,
 diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
-index 25ffe45..55e6432 100644
+index abd12c20eb..6d68a534a7 100644
 --- a/dlls/wined3d/wined3d_private.h
 +++ b/dlls/wined3d/wined3d_private.h
 @@ -75,6 +75,7 @@
@@ -92,5 +93,5 @@ index 25ffe45..55e6432 100644
  enum wined3d_ffp_idx
  {
 -- 
-2.16.3
+2.17.0
 

--- a/patches/0010-wined3d-knobs-and-switches.patch
+++ b/patches/0010-wined3d-knobs-and-switches.patch
@@ -1,0 +1,140 @@
+From 4d897e40ec005d1452a2a94200754213e63b44cb Mon Sep 17 00:00:00 2001
+From: Firerat <firer4t@googlemail.com>
+Date: Sat, 31 Mar 2018 00:43:33 +0100
+Subject: [PATCH 10/10] wined3d: knobs and switches
+
+patch adds envvars to tweak PBA, for better or for worse.
+
+envvars __PBA_GEO_HEAP and __PBA_CB_HEAP
+  e.g. __PBA_GEO_HEAP=256 __PBA_CB_HEAP=64
+    known to prevent FF XIV 32bit dx9 client crash.
+  will fallback to defaults if heaps are greater than vram
+
+  if vram is less than 640mb ( 512+128 ) the defaults are crudely
+  calculated, geo 3/4 vram and cb 1/8 vram.
+
+  cb can be set at 0, but only intended for pure dx8 or dx9.
+
+envvar __PBA_FORCE_GL_CLIENT_STORAGE_BIT
+  force use of DMA_CACHE instead of SYSTEM_HEAP
+    no effect when using mesa
+---
+ dlls/wined3d/buffer_heap.c |  9 +++++-
+ dlls/wined3d/device.c      | 56 ++++++++++++++++++++++++++++++++++----
+ 2 files changed, 58 insertions(+), 7 deletions(-)
+
+diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
+index 9e8f2d799d..31029a4fc1 100644
+--- a/dlls/wined3d/buffer_heap.c
++++ b/dlls/wined3d/buffer_heap.c
+@@ -176,7 +176,14 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
+     // Hints are awful anyway.
+     if (gl_info->quirks & WINED3D_QUIRK_USE_CLIENT_STORAGE_BIT)
+     {
+-        FIXME_(d3d_perf)("PBA: using GL_CLIENT_STORAGE_BIT quirk");
++        FIXME_(d3d_perf)("PBA: using GL_CLIENT_STORAGE_BIT quirk (mesa)\n");
++        storage_flags |= GL_CLIENT_STORAGE_BIT;
++    }
++
++    const char *env_pba_force_gcsb = getenv("__PBA_FORCE_GL_CLIENT_STORAGE_BIT");
++    if (!(gl_info->quirks & WINED3D_QUIRK_USE_CLIENT_STORAGE_BIT) && (env_pba_force_gcsb))
++    {
++        FIXME_(d3d_perf)("PBA: forcing use of GL_CLIENT_STORAGE_BIT quirk (__PBA_FORCE_GL_CLIENT_STORAGE_BIT=%s)\n",env_pba_force_gcsb);
+         storage_flags |= GL_CLIENT_STORAGE_BIT;
+     }
+ 
+diff --git a/dlls/wined3d/device.c b/dlls/wined3d/device.c
+index 9a8bade7e9..bdd7fb1401 100644
+--- a/dlls/wined3d/device.c
++++ b/dlls/wined3d/device.c
+@@ -35,6 +35,7 @@
+ #include "wined3d_private.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(d3d);
++WINE_DECLARE_DEBUG_CHANNEL(d3d_perf);
+ WINE_DECLARE_DEBUG_CHANNEL(winediag);
+ 
+ /* Define the default light parameters as specified by MSDN. */
+@@ -849,7 +850,7 @@ static void create_buffer_heap(struct wined3d_device *device, struct wined3d_con
+ 
+     if (!gl_info->supported[ARB_BUFFER_STORAGE])
+     {
+-        FIXME("Not using PBA, ARB_buffer_storage unsupported.\n");
++        FIXME_(d3d_perf)("Not using PBA, ARB_buffer_storage unsupported.\n");
+     }
+     else if ((env_pba_disable = getenv("PBA_DISABLE")) && *env_pba_disable != '0')
+     {
+@@ -857,11 +858,47 @@ static void create_buffer_heap(struct wined3d_device *device, struct wined3d_con
+     }
+     else
+     {
++        //(Firerat) is it worth initialising an int for vram?
++        unsigned int vram_mb = device->adapter->vram_bytes / 1048576;
++        const char *env_pba_geo_heap = getenv("__PBA_GEO_HEAP");
+         // TODO(acomminos): kill this magic number. perhaps base on vram.
+-        GLsizeiptr geo_heap_size = 512 * 1024 * 1024;
++        unsigned int geo_heap = ( env_pba_geo_heap ? atoi(env_pba_geo_heap) : 512 );
++        const char *env_pba_cb_heap = getenv("__PBA_CB_HEAP");
+         // We choose a constant buffer size of 128MB, the same as NVIDIA claims to
+         // use in their Direct3D driver for discarded constant buffers.
+-        GLsizeiptr cb_heap_size = 128 * 1024 * 1024;
++        unsigned int cb_heap = ( env_pba_cb_heap ? atoi(env_pba_cb_heap) : 128 );
++
++        if (env_pba_geo_heap)
++        {
++            FIXME_(d3d_perf)("geo_heap_size set by envvar __PBA_GEO_HEAP=%s\n",env_pba_geo_heap);
++        }
++        if (env_pba_cb_heap)
++        {
++            FIXME_(d3d_perf)("cb_heap_size set by envvar __PBA_CB_HEAP=%s\n",env_pba_cb_heap);
++        }
++
++        if ( geo_heap + cb_heap > vram_mb )
++        {
++            FIXME_(d3d_perf)("geo_heap + cb_heap ( %dmb + %dmb ) exceeds vram of %dmb. Dropping back to PBA defaults\n", geo_heap, cb_heap, vram_mb);
++            if ( vram_mb <= 640 ) // most users should have plenty of vram, but if not at least try to give them PBA..
++            {
++                //TODO (Firerat) I should probably figure out if using dx10+ ( possible? ), could skip cb_heap if not
++                FIXME_(d3d_perf)("You have low vram(%dmb), making crude guess at reasonable heap sizes for PBA\n", vram_mb);
++                // very crude, using 87.5% of vram
++                geo_heap = vram_mb * 0.75; // 3 quarters of vram
++                cb_heap = vram_mb * 0.125; // 8th of vram, probably too low
++                FIXME_(d3d_perf)("guess expressed as envvars: __PBA_GEO_HEAP=%d __PBA_CB_HEAP=%d\n", geo_heap, cb_heap);
++                //TODO (Firerat) might not be worth messing about here, just fail with note about envvars
++            }
++            else
++            {
++                // should ony get here if user screwed up their pba envvars
++                geo_heap = 512;
++                cb_heap = 128;
++            }
++        }
++        GLsizeiptr geo_heap_size = geo_heap * 1024 * 1024;
++        GLsizeiptr cb_heap_size = cb_heap * 1024 * 1024;
+         GLint ub_alignment;
+         HRESULT hr;
+ 
+@@ -876,10 +913,17 @@ static void create_buffer_heap(struct wined3d_device *device, struct wined3d_con
+             goto fail;
+         }
+ 
+-        if (FAILED(hr = wined3d_buffer_heap_create(context, cb_heap_size, ub_alignment, TRUE, &device->cb_buffer_heap)))
++        if (cb_heap != 0) // assume user doesn't want a cb_heap , e.g. not dx10+
+         {
+-            ERR("Failed to create persistent buffer heap for constant buffers, hr %#x.\n", hr);
+-            goto fail;
++            if (FAILED(hr = wined3d_buffer_heap_create(context, cb_heap_size, ub_alignment, TRUE, &device->cb_buffer_heap)))
++            {
++                ERR("Failed to create persistent buffer heap for constant buffers, hr %#x.\n", hr);
++                goto fail;
++            }
++        }
++        else
++        {
++            FIXME_(d3d_perf)("cb_heap set to 0, this will degrade performance with dx10 and dx11\n");
+         }
+ 
+         FIXME("Initialized PBA (geo_heap_size: %ld, cb_heap_size: %ld, ub_align: %d)\n", geo_heap_size, cb_heap_size, ub_alignment);
+-- 
+2.17.0
+

--- a/patches/0010-wined3d-knobs-and-switches.patch
+++ b/patches/0010-wined3d-knobs-and-switches.patch
@@ -37,7 +37,7 @@ index 9e8f2d799d..31029a4fc1 100644
 +    }
 +
 +    const char *env_pba_force_gcsb = getenv("__PBA_FORCE_GL_CLIENT_STORAGE_BIT");
-+    if (!(gl_info->quirks & WINED3D_QUIRK_USE_CLIENT_STORAGE_BIT) && (env_pba_force_gcsb))
++    if (!(gl_info->quirks & WINED3D_QUIRK_USE_CLIENT_STORAGE_BIT) && ((env_pba_force_gcsb) && *env_pba_force_gcsb != '0'))
 +    {
 +        FIXME_(d3d_perf)("PBA: forcing use of GL_CLIENT_STORAGE_BIT quirk (__PBA_FORCE_GL_CLIENT_STORAGE_BIT=%s)\n",env_pba_force_gcsb);
          storage_flags |= GL_CLIENT_STORAGE_BIT;

--- a/patches/0010-wined3d-knobs-and-switches.patch
+++ b/patches/0010-wined3d-knobs-and-switches.patch
@@ -1,4 +1,4 @@
-From 4d897e40ec005d1452a2a94200754213e63b44cb Mon Sep 17 00:00:00 2001
+From 8a142cda503dd2e1104a6a07f3cbf096756adcbe Mon Sep 17 00:00:00 2001
 From: Firerat <firer4t@googlemail.com>
 Date: Sat, 31 Mar 2018 00:43:33 +0100
 Subject: [PATCH 10/10] wined3d: knobs and switches
@@ -24,7 +24,7 @@ envvar __PBA_FORCE_GL_CLIENT_STORAGE_BIT
  2 files changed, 58 insertions(+), 7 deletions(-)
 
 diff --git a/dlls/wined3d/buffer_heap.c b/dlls/wined3d/buffer_heap.c
-index 9e8f2d799d..31029a4fc1 100644
+index 9e8f2d799d..320b077782 100644
 --- a/dlls/wined3d/buffer_heap.c
 +++ b/dlls/wined3d/buffer_heap.c
 @@ -176,7 +176,14 @@ HRESULT wined3d_buffer_heap_create(struct wined3d_context *context, GLsizeiptr s
@@ -44,7 +44,7 @@ index 9e8f2d799d..31029a4fc1 100644
      }
  
 diff --git a/dlls/wined3d/device.c b/dlls/wined3d/device.c
-index 9a8bade7e9..bdd7fb1401 100644
+index 098e04ef1c..df8e2f3f54 100644
 --- a/dlls/wined3d/device.c
 +++ b/dlls/wined3d/device.c
 @@ -35,6 +35,7 @@


### PR DESCRIPTION
for better or for worse, adds envvars to tweak PBA
  primarily to resolve issues such as FF XIV 32bit dx9 client crash
    where __PBA_GEO_HEAP=256 __PBA_CB_HEAP=64 is known to work.

  __PBA_GEO_HEAP=2048 seems to allow vegetation in The Witcher 3
  __PBA_GEO_HEAP=2048 also seems to eliminate 'render lag' in warframes
   Note: I'm unable to confirm these.

  __PBA_FORCE_GL_CLIENT_STORAGE_BIT , forces use of dma cached mem
    has no effect on users of mesa

Closes (https://github.com/Firerat/wine-pba/issues/2)

README.md: update base to wine-staging 3.5
Closes (#54)